### PR TITLE
added fix for getmethod to avoid infinite loop

### DIFF
--- a/src/main/java/io/forty11/j/api/Lang.java
+++ b/src/main/java/io/forty11/j/api/Lang.java
@@ -632,6 +632,11 @@ public class Lang
             if (m.getName().equalsIgnoreCase(name))
                return m;
          }
+         
+         if (clazz != null)
+         {
+            clazz = clazz.getSuperclass();
+         }
       }
       while (clazz != null && !Object.class.equals(clazz));
 


### PR DESCRIPTION
I'm not sure if this code has changed recently, but if the class doesn't have the method this will get in an infinite loop.